### PR TITLE
fix linking of stubs

### DIFF
--- a/stubs/Makefile
+++ b/stubs/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -O2
+CFLAGS = -O2 -fPIC
 
 
 all: CoreFoundation.so libOSXWindowManagement.so


### PR DESCRIPTION
on fedora, this is necessary due to some hardening in place that makes the linker more strict about relocation or something

please verify if this breaks anything on other platforms, if so, we need to be smarter in the Makefile