### PR TITLE
fix generated desktop entry

### DIFF
--- a/craft.sh
+++ b/craft.sh
@@ -196,7 +196,7 @@ cat <<EOF >~/.local/share/applications/hearthstone.desktop
 [Desktop Entry]
 Type=Application
 Name=Hearthstone
-Exec=$TARGET_PATH/Bin/Hearthstone.x86_64
+Exec=sh -c "cd $TARGET_PATH && ./Bin/Hearthstone.x86_64"
 Icon=$TARGET_PATH/Bin/Hearthstone_Data/Resources/PlayerIcon.icns
 Categories=Game;
 EOF


### PR DESCRIPTION
when executing ./Bin/Hearthstone.x64_64 from outside the target path, one gets a message hearthstone requires the "battle.net" client or something

this small change fixes that