### PR TITLE
Use Path key instead of cd'ing into the working directory

### DIFF
--- a/craft.sh
+++ b/craft.sh
@@ -239,7 +239,8 @@ cat <<EOF >~/.local/share/applications/hearthstone.desktop
 [Desktop Entry]
 Type=Application
 Name=Hearthstone
-Exec=sh -c "cd $TARGET_PATH && ./Bin/Hearthstone.x86_64"
+Path=$TARGET_PATH
+Exec=./Bin/Hearthstone.x86_64"
 Icon=$TARGET_PATH/Bin/Hearthstone_Data/Resources/PlayerIcon.icns
 Categories=Game;
 StartupWMClass=Hearthstone.x86_64


### PR DESCRIPTION
There's a designated "Parth" key for .desktop entries (see [here](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html)) changed it since cd'ing into the directory didn't work for me.

Tested on Arch Linux