### PR TITLE
Add full window title to login window

### DIFF
--- a/login/login.c
+++ b/login/login.c
@@ -121,6 +121,7 @@ int main(int argc, char *argv[]) {
     win = gtk_window_new(GTK_WINDOW_TOPLEVEL);
     gtk_window_set_default_size(GTK_WINDOW(win), 480, 420);
     gtk_window_set_position(GTK_WINDOW(win), GTK_WIN_POS_CENTER);
+    gtk_window_set_title(GTK_WINDOW(win), "Battle.net Login");
 
     web = WEBKIT_WEB_VIEW(webkit_web_view_new());
     gtk_container_add(GTK_CONTAINER(win), GTK_WIDGET(web));


### PR DESCRIPTION
Not an important change, but I noticed that the window title wasn't "Battle.net Login," as it is in the browser. This PR would just set the window title to "Battle.net Login."