### PR TITLE
change cn version url

### DIFF
--- a/craft.sh
+++ b/craft.sh
@@ -80,7 +80,7 @@ check_version() {
     set_locale
     # when region is cn, change the url into  https://cn.version.battlenet.com.cn/hsb/versions
     if [ "${REGION}" = "cn" ]; then
-        VERSION=$(curl -s https://cn.version.battle.net/hsb/versions | grep cn)
+        VERSION=$(curl -s https://cn.version.battlenet.com.cn/hsb/versions | grep cn)
     else
         VERSION=$(curl -s http://${REGION}.patch.battle.net:1119/hsb/versions | grep $REGION)
     fi

--- a/craft.sh
+++ b/craft.sh
@@ -78,7 +78,12 @@ init_hearthstone() {
 check_version() {
     set_region
     set_locale
-    VERSION=$(curl -s http://${REGION}.patch.battle.net:1119/hsb/versions | grep $REGION)
+    # when region is cn, change the url into  https://cn.version.battlenet.com.cn/hsb/versions
+    if [ "${REGION}" = "cn" ]; then
+        VERSION=$(curl -s https://cn.version.battle.net/hsb/versions | grep cn)
+    else
+        VERSION=$(curl -s http://${REGION}.patch.battle.net:1119/hsb/versions | grep $REGION)
+    fi
     VERSION=${VERSION%|*}
     VERSION=${VERSION##*|}
 


### PR DESCRIPTION
when visiting http://cn.patch.battle.net:1119/hsb/versions it shows moved permanently
```text
curl http://cn.patch.battle.net:1119/hsb/versions
HTTP/1.1 301 Moved Permanently
Server: nginx/1.18.0 (Ubuntu)
Date: Fri, 11 Oct 2024 00:14:41 GMT
Content-Type: text/html
Content-Length: 178
Connection: keep-alive
Location: https://cn.version.battlenet.com.cn/hsb/versions

<html>
<head><title>301 Moved Permanently</title></head>
<body>
<center><h1>301 Moved Permanently</h1></center>
<hr><center>nginx/1.18.0 (Ubuntu)</center>
</body>
</html>
```

so i changed the url for cn
