### PR TITLE
Fix error creating `hearthstone.desktop` if directory doesn't exist

### DIFF
--- a/craft.sh
+++ b/craft.sh
@@ -238,6 +238,8 @@ check_unity $2
 popd
 create_compatibility_files
 
+mkdir -p ~/.local/share/applications
+
 cat <<EOF >~/.local/share/applications/hearthstone.desktop
 [Desktop Entry]
 Type=Application


### PR DESCRIPTION
On a fresh Kubuntu install this directory does not yet exist so the .desktop file never gets created