### PR TITLE
Fix `pkg-config` webkit version picking

### DIFF
--- a/login/Makefile
+++ b/login/Makefile
@@ -1,5 +1,5 @@
 CC = g++
-FLAGS = `pkg-config --cflags --libs gtk+-3.0 $(shell pkg-config --list-package-names | grep webkit2gtk-4.)`
+FLAGS = `pkg-config --cflags --libs gtk+-3.0 $(shell pkg-config --list-package-names | grep webkit2gtk-4. | sort | tail -n1)`
 
 all: login
 .PHONY: all


### PR DESCRIPTION
### Description

The current `Makefile` for `login` isn't designed right now for cases where user might have multiple versions installed of `webkit4.*`. Due to this actually being the case for some standard distro envs (Arch-based ones being the example), it's possibly better to additionally sort the `grep` output and return the last (newest) library version, in order to avoid weird linking issues like with `libsoup2` / `libsoup3` symbols mixing.

### Commit message

> Add additional command pipeline to sort and ensure the latest  version of `webkit4.*` is being picked by `grep`'d `pkg-config`.
> 
> Fixes: #77
> Fixes: #80