### PR TITLE
Fix a corrupted db state

### DIFF
--- a/craft.sh
+++ b/craft.sh
@@ -233,6 +233,13 @@ check_directory() {
         init_hearthstone
     else
         pushd hearthstone
+        # Reinitialize ngdp if db is corrupt/empty
+        if [ ! -s .ngdp/keg.db ] || ! $NGDP_BIN fsck >/dev/null 2>&1; then
+            warn "keg database is empty or corrupt, reinitializing ..."
+            set_region
+            $NGDP_BIN init
+            $NGDP_BIN remote add http://${REGION}.patch.battle.net:1119/hsb
+        fi
     fi
 
     # Update procedure


### PR DESCRIPTION
I basically typed a wrong region in the input and that kinda corrupted the ngdp db. And simple recreation works.

Here is the log with a corrupt db.
```
Fetching http://eu.patch.battle.net:1119/hsb
Receiving CDN listTraceback (most recent call last):
  File "/home/user/hearthstone-linux/keg/bin/ngdp", line 1048, in <module>
    main()
    ~~~~^^
  File "/home/user/hearthstone-linux/venv/lib/python3.14/site-packages/click/core.py", line 1485, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/user/hearthstone-linux/venv/lib/python3.14/site-packages/click/core.py", line 1406, in main
    rv = self.invoke(ctx)
  File "/home/user/hearthstone-linux/venv/lib/python3.14/site-packages/click/core.py", line 1873, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/home/user/hearthstone-linux/venv/lib/python3.14/site-packages/click/core.py", line 1269, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/hearthstone-linux/venv/lib/python3.14/site-packages/click/core.py", line 824, in invoke
    return callback(*args, **kwargs)
  File "/home/user/hearthstone-linux/venv/lib/python3.14/site-packages/click/decorators.py", line 34, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/user/hearthstone-linux/keg/bin/ngdp", line 306, in fetch
    cdns, versions, blobs = ctx.obj.fetch_stateful_data(http_remote)
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/home/user/hearthstone-linux/keg/bin/ngdp", line 121, in fetch_stateful_data
    cdns = remote.get_cdns()
  File "/home/user/hearthstone-linux/venv/lib/python3.14/site-packages/keg/remote/base.py", line 22, in get_cdns
    psvfile, _ = self.get_psv("cdns")
                 ~~~~~~~~~~~~^^^^^^^^
  File "/home/user/hearthstone-linux/venv/lib/python3.14/site-packages/keg/remote/cache.py", line 31, in get_psv
    self.cache_db.write_psv(psvfile, response.digest, self.remote, name)
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/hearthstone-linux/venv/lib/python3.14/site-packages/keg/core/db.py", line 278, in write_psv
    cursor.execute(
    ~~~~~~~~~~~~~~^
    	f"""
     ^^^^
    ...<5 lines>...
    	(remote, key),
     ^^^^^^^^^^^^^^
    )
    ^
```