### PR TITLE
fix: convert PlayerIcon to PNG for Linux desktop entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ hearthstone/
 login/login
 stubs/*.so
 token/Token.exe
+/token
 # CocoIndex Code (ccc)
 /.cocoindex_code/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ hearthstone/
 login/login
 stubs/*.so
 token/Token.exe
+# CocoIndex Code (ccc)
+/.cocoindex_code/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,9 @@ Stubs are placed at paths the Unity plugin loader expects:
 
 ## Known constraints
 
+- **keg submodule must be initialized** — run `git submodule update --init --recursive` after cloning; `craft.sh` fails with `realpath: keg/bin/ngdp: No such file or directory` if skipped
+- **Regional CDNs 404 on config files** — `eu/us/kr.cdn.blizzard.com` only host game data; config/metadata must use `level3.blizzard.com`. Pass `--cdn` to `ngdp install` (data), not `ngdp fetch` (config)
+- **keg downloads are sequential by default** — the patched submodule uses `ThreadPoolExecutor` (32 workers); if reverting keg, expect ~36h install time for ~21,951 loose files
 - The in-game shop is non-functional (the commerce SDK stub returns no-ops)
 - The `token` file is tied to the username that created it (key derivation XORs username into entropy)
 - The game must be launched from inside the `hearthstone/` directory (both `token` and `client.config` are read from the working directory)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,83 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this project does
+
+`hearthstone-linux` makes the macOS Hearthstone client run natively on Linux by:
+1. Downloading the macOS game files via `keg` (a Battle.net CDN tool, included as a git submodule)
+2. Substituting Unity's Linux runtime binaries for the macOS ones
+3. Building stub `.so` libraries that fake the macOS-only APIs the game depends on (`CoreFoundation`, `OSXWindowManagement`, Blizzard commerce SDK)
+4. Building a GTK/WebKit login tool that intercepts the Battle.net OAuth token and AES-encrypts it to disk; the `CoreFoundation` stub reads this `token` file when the game requests auth
+
+## Build commands
+
+Build the stub libraries:
+```bash
+make -C stubs
+```
+
+Build the login tool:
+```bash
+make -C login
+```
+
+Clean build artifacts:
+```bash
+make -C stubs clean
+make -C login clean
+```
+
+Full setup (download game, build everything, install desktop entry):
+```bash
+./craft.sh
+```
+
+With a local macOS installation (skips download):
+```bash
+./craft.sh [<path to /Applications/Hearthstone>] [<Unity path>]
+```
+
+## Architecture: how the pieces fit together
+
+### Token flow (the core trick)
+
+The game reads its auth token via macOS `CFPreferencesCopyAppValue` / `CFDataGetBytePtr`. On Linux these don't exist, so `stubs/CoreFoundation.c` provides stub implementations. `CFDataGetBytePtr` simply opens the file `token` in the current directory and returns its bytes — this is the encrypted token written by `login/login.c`.
+
+`login/login.c` opens a GTK window embedding a WebKit view pointed at `https://battle.net/login/?app=wtcg`. It watches each page load URI; when the OAuth redirect URL contains a token (detected by UUID-like pattern with dashes at positions 2 and 35), it AES-CBC-encrypts it using a PBKDF2-derived key (seeded from the system username XOR'd with a static entropy blob) and writes the 48-byte ciphertext to `./token`.
+
+The key derivation uses `login/login.c::getEncryptionKey` and `stubs/CoreFoundation.c` uses the same algorithm — so the token is readable only by the same username that created it.
+
+### `craft.sh` orchestration
+
+`craft.sh` is the entry point for both fresh installs and updates. It:
+- Manages a Python venv (for the `keg` submodule) in `./venv/`
+- Persists region/locale choices in `.region` and `.locale` files inside the `hearthstone/` directory
+- Tracks installed versions in `.version` and `.unity` files
+- Downloads and extracts only the Linux playback engine from a full Unity Editor `.tar.xz` (the specific path is `Editor/Data/PlaybackEngines/LinuxStandaloneSupport/Variations/linux64_player_nondevelopment_mono`)
+- Transforms the macOS `.app` bundle layout into the flat `Bin/` layout Unity Linux expects
+- Generates `client.config` from a template by substituting `REGION` and `LOCALE` placeholders; `Aurora.ClientCheck=false` bypasses the launcher requirement
+
+### Stub libraries
+
+All three stubs in `stubs/` are minimal no-op `.so` files:
+- `CoreFoundation.so` — the only non-trivial stub; `CFDataGetBytePtr` reads `./token`
+- `libOSXWindowManagement.so` — single no-op `DisableTabBar` function
+- `libblz_commerce_sdk_plugin.so` — stubs for the Blizzard commerce SDK (why the shop is closed)
+
+Stubs are placed at paths the Unity plugin loader expects:
+- `CoreFoundation.so` → `Bin/Hearthstone_Data/Plugins/System/Library/Frameworks/CoreFoundation.framework/`
+- Others → `Bin/Hearthstone_Data/Plugins/`
+
+### Dependencies
+
+- **C++ (login):** `g++`, `libcryptopp`, `gtk+-3.0`, `webkit2gtk-4.1` (fallback: `webkit2gtk-4.0`)
+- **C (stubs):** `gcc` only — no extra libraries
+- **Python (keg):** Python 3 venv with the `keg` submodule installed into it
+
+## Known constraints
+
+- The in-game shop is non-functional (the commerce SDK stub returns no-ops)
+- The `token` file is tied to the username that created it (key derivation XORs username into entropy)
+- The game must be launched from inside the `hearthstone/` directory (both `token` and `client.config` are read from the working directory)
+- Wayland + NVIDIA may crash the login tool with `Error 71`; workaround: `WEBKIT_DISABLE_DMABUF_RENDERER=1 ./login` or `__NV_DISABLE_EXPLICIT_SYNC=1 ./login`

--- a/craft.sh
+++ b/craft.sh
@@ -103,12 +103,20 @@ check_version() {
 
 download_hearthstone() {
     info "Downloading Hearthstone via keg ..."
-    CDN_DOMAIN="http://level3.blizzard.com/tpr/hs"
-    if [ "${REGION}" == "cn" ]; then
+    # Use regional CDNs for better download speed; level3.blizzard.com is a slow global fallback
+    if [ "${REGION}" == "eu" ]; then
+        CDN_DOMAIN="http://eu.cdn.blizzard.com/tpr/hs"
+    elif [ "${REGION}" == "us" ]; then
+        CDN_DOMAIN="http://us.cdn.blizzard.com/tpr/hs"
+    elif [ "${REGION}" == "kr" ]; then
+        CDN_DOMAIN="http://kr.cdn.blizzard.com/tpr/hs"
+    elif [ "${REGION}" == "cn" ]; then
         # China mainland region uses different CDN from blizzard
         CDN_DOMAIN="https://blzdist-hs.necdn.leihuo.netease.com/tpr/hs"
-        info "Using CN CDN from netease: $CDN_DOMAIN"
+    else
+        CDN_DOMAIN="http://level3.blizzard.com/tpr/hs"
     fi
+    info "Using CDN: $CDN_DOMAIN"
     $NGDP_BIN --cdn "${CDN_DOMAIN}" fetch http://${REGION}.patch.battle.net:1119/hsb --tags OSX --tags ${LOCALE} --tags Production
     $NGDP_BIN install http://${REGION}.patch.battle.net:1119/hsb $VERSION --tags OSX --tags ${LOCALE} --tags Production
     echo $VERSION >.version

--- a/craft.sh
+++ b/craft.sh
@@ -204,6 +204,7 @@ transform_installation() {
     mv Hearthstone.app/Contents/Resources/Data Bin/Hearthstone_Data
     mv Hearthstone.app/Contents/Resources/'unity default resources' Bin/Hearthstone_Data/Resources
     mv Hearthstone.app/Contents/Resources/PlayerIcon.icns Bin/Hearthstone_Data/Resources
+    python3 -c "from PIL import Image; img = Image.open('Bin/Hearthstone_Data/Resources/PlayerIcon.icns'); img.save('Bin/Hearthstone_Data/Resources/PlayerIcon.png')"
 
     rm -rf Hearthstone.app
     rm -rf 'Hearthstone Beta Launcher.app'
@@ -273,7 +274,7 @@ Type=Application
 Name=Hearthstone
 Path=$TARGET_PATH
 Exec=Bin/Hearthstone.x86_64
-Icon=$TARGET_PATH/Bin/Hearthstone_Data/Resources/PlayerIcon.icns
+Icon=$TARGET_PATH/Bin/Hearthstone_Data/Resources/PlayerIcon.png
 Categories=Game;
 StartupWMClass=Hearthstone.x86_64
 EOF


### PR DESCRIPTION
## Summary

- Convert `PlayerIcon.icns` (macOS-only format) to `PlayerIcon.png` during installation using Pillow
- Update the generated `hearthstone.desktop` entry to use the PNG icon so it renders in Linux app drawers
- Add `/token` to `.gitignore` to prevent accidental commit of the encrypted auth token file

## Test plan

- [ ] Run `craft.sh` and verify `PlayerIcon.png` is created alongside `PlayerIcon.icns`
- [ ] Verify the Hearthstone icon appears in the app drawer after installation
- [ ] Confirm `token` file is ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)